### PR TITLE
Add cut-and-stack PDF ordering

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,6 +28,7 @@ function App() {
             allVariants={state.allVariants} setAllVariants={actions.setAllVariants}
             includeCameos={state.includeCameos} setIncludeCameos={actions.setIncludeCameos}
             cardsPerPage={state.cardsPerPage} setCardsPerPage={actions.setCardsPerPage}
+            cutAndStack={state.cutAndStack} setCutAndStack={actions.setCutAndStack}
             sortBy={state.sortBy} setSortBy={actions.setSortBy}
             loading={state.loading}
             isFormValid={state.isFormValid}

--- a/src/__tests__/PdfService.test.js
+++ b/src/__tests__/PdfService.test.js
@@ -1,0 +1,39 @@
+import { PdfService } from '../services/PdfService';
+
+describe('PdfService.reorderForCutAndStack', () => {
+  const cards = (n) => Array.from({ length: n }, (_, i) => ({ id: i }));
+
+  test('reorders so stacking piles yields sequential order', () => {
+    // 9 cards / page, 20 cards → 3 pages
+    const ordered = PdfService.reorderForCutAndStack(cards(20), 9);
+
+    // Page 0, slots 0..8
+    expect(ordered.slice(0, 9).map((c) => (c ? c.id : null))).toEqual([
+      0, 3, 6, 9, 12, 15, 18, null, null,
+    ]);
+    // Page 1
+    expect(ordered.slice(9, 18).map((c) => (c ? c.id : null))).toEqual([
+      1, 4, 7, 10, 13, 16, 19, null, null,
+    ]);
+    // Page 2
+    expect(ordered.slice(18, 27).map((c) => (c ? c.id : null))).toEqual([
+      2, 5, 8, 11, 14, 17, null, null, null,
+    ]);
+
+    // Simulate cutting into 9 piles (same slot across pages), then stacking piles 0..8
+    const piles = Array.from({ length: 9 }, () => []);
+    for (let page = 0; page < 3; page++) {
+      for (let slot = 0; slot < 9; slot++) {
+        const card = ordered[page * 9 + slot];
+        if (card) piles[slot].push(card.id);
+      }
+    }
+    const stacked = piles.flat();
+    expect(stacked).toEqual(Array.from({ length: 20 }, (_, i) => i));
+  });
+
+  test('handles exact page fills', () => {
+    const ordered = PdfService.reorderForCutAndStack(cards(9), 9);
+    expect(ordered.map((c) => c.id)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+});

--- a/src/components/FilterForm.js
+++ b/src/components/FilterForm.js
@@ -10,6 +10,7 @@ const FilterForm = ({
   allVariants, setAllVariants,
   includeCameos, setIncludeCameos,
   cardsPerPage, setCardsPerPage,
+  cutAndStack, setCutAndStack,
   sortBy, setSortBy,
   loading,
   isFormValid,
@@ -275,6 +276,21 @@ const FilterForm = ({
             </svg>
             Note: Increasing the number of cards per page will reduce the individual card size.
           </p>
+        </div>
+
+        <div
+          className="md:col-span-2 flex items-center space-x-3 bg-slate-50 px-4 py-3 rounded-xl border-2 border-slate-100 cursor-pointer hover:border-slate-200 transition-all duration-200 group relative"
+          onClick={() => setCutAndStack(!cutAndStack)}
+        >
+          <div className={`w-10 h-6 flex items-center rounded-full p-1 transition-colors duration-200 ${cutAndStack ? 'bg-red-500' : 'bg-slate-300'}`}>
+            <div className={`bg-white w-4 h-4 rounded-full shadow-sm transform transition-transform duration-200 ${cutAndStack ? 'translate-x-4' : 'translate-x-0'}`}></div>
+          </div>
+          <div className="flex-grow">
+            <span className="text-sm font-bold text-slate-700 select-none">Cut &amp; Stack Order</span>
+            <p className="text-[11px] text-slate-400 mt-0.5 select-none">
+              Arrange cards so stacking cut piles (left-to-right, top-to-bottom) keeps them in order.
+            </p>
+          </div>
         </div>
 
         <div className="md:col-span-2 space-y-1.5">

--- a/src/hooks/useCardGenerator.js
+++ b/src/hooks/useCardGenerator.js
@@ -14,6 +14,7 @@ export const useCardGenerator = () => {
   const [allVariants, setAllVariants] = useState(false);
   const [includeCameos, setIncludeCameos] = useState(false);
   const [cardsPerPage, setCardsPerPage] = useState(9);
+  const [cutAndStack, setCutAndStack] = useState(true);
   const [error, setError] = useState(null);
   const [progress, setProgress] = useState(null);
   const [status, setStatus] = useState('');
@@ -96,7 +97,7 @@ export const useCardGenerator = () => {
       } else {
         setStatus(`Generating PDF for ${allFoundCards.length} cards...`);
         const sortedCards = CardService.sortCards(allFoundCards, sortBy);
-        await PdfService.generatePdf(sortedCards, { useImages, showVariant: allVariants, cardsPerPage }, (p) => {
+        await PdfService.generatePdf(sortedCards, { useImages, showVariant: allVariants, cardsPerPage, cutAndStack }, (p) => {
           // PDF generation is 30-100%
           setProgress(30 + Math.round((p / 100) * 70));
         });
@@ -126,6 +127,7 @@ export const useCardGenerator = () => {
       allVariants,
       includeCameos,
       cardsPerPage,
+      cutAndStack,
       error,
       progress,
       status,
@@ -141,6 +143,7 @@ export const useCardGenerator = () => {
       setAllVariants,
       setIncludeCameos,
       setCardsPerPage,
+      setCutAndStack,
       handleGenerate
     }
   };

--- a/src/services/PdfService.js
+++ b/src/services/PdfService.js
@@ -1,8 +1,29 @@
 import { jsPDF } from 'jspdf';
 
 export const PdfService = {
+  /**
+   * Reorder cards so that after cutting a printed grid into piles and stacking
+   * those piles in reading order (top-left → bottom-right), the deck is sequential.
+   *
+   * Slot `s` on page `p` gets card index `s * numPages + p`.
+   */
+  reorderForCutAndStack: (cards, cardsPerPage) => {
+    const slotsPerPage = cardsPerPage;
+    const numPages = Math.ceil(cards.length / slotsPerPage);
+    const ordered = [];
+
+    for (let page = 0; page < numPages; page++) {
+      for (let slot = 0; slot < slotsPerPage; slot++) {
+        const cardIndex = slot * numPages + page;
+        ordered.push(cardIndex < cards.length ? cards[cardIndex] : null);
+      }
+    }
+
+    return ordered;
+  },
+
   generatePdf: async (cards, options = {}, onProgress) => {
-    const { useImages = false, showVariant = true, cardsPerPage = 9 } = options;
+    const { useImages = false, showVariant = true, cardsPerPage = 9, cutAndStack = false } = options;
     const doc = new jsPDF({
       unit: 'in',
       format: 'letter'
@@ -48,29 +69,35 @@ export const PdfService = {
     // Set line width for card borders
     doc.setLineWidth(borderWidth);
 
-    for (let i = 0; i < cards.length; i++) {
-      const card = cards[i];
+    const slots = cutAndStack
+      ? PdfService.reorderForCutAndStack(cards, cardsPerPage)
+      : cards;
+
+    for (let i = 0; i < slots.length; i++) {
+      const card = slots[i];
 
       if (onProgress) {
-        onProgress(Math.round((i / cards.length) * 100));
+        onProgress(Math.round((i / slots.length) * 100));
       }
 
       // Draw cell border
       doc.rect(x, y, cellWidth, cellHeight);
 
-      if (useImages && card.image_url) {
-        try {
-          const imgData = await PdfService.getImageData(card.image_url);
-          doc.addImage(imgData, 'JPEG', x, y, cellWidth, cellHeight);
-          if (showVariant) {
-            PdfService.drawOverlay(doc, card, x, y, cellWidth, cellHeight, showVariant);
+      if (card) {
+        if (useImages && card.image_url) {
+          try {
+            const imgData = await PdfService.getImageData(card.image_url);
+            doc.addImage(imgData, 'JPEG', x, y, cellWidth, cellHeight);
+            if (showVariant) {
+              PdfService.drawOverlay(doc, card, x, y, cellWidth, cellHeight, showVariant);
+            }
+          } catch (e) {
+            console.error(`Failed to load image for ${card.name}`, e);
+            PdfService.drawText(doc, card, x, y, cellWidth, cellHeight, showVariant, cardsPerPage);
           }
-        } catch (e) {
-          console.error(`Failed to load image for ${card.name}`, e);
+        } else {
           PdfService.drawText(doc, card, x, y, cellWidth, cellHeight, showVariant, cardsPerPage);
         }
-      } else {
-        PdfService.drawText(doc, card, x, y, cellWidth, cellHeight, showVariant, cardsPerPage);
       }
 
       // Move to next cell
@@ -84,7 +111,7 @@ export const PdfService = {
 
       // New page
       if (y + (cellHeight / 2) > pageHeight - bottomMargin) {
-        if (i < cards.length - 1) {
+        if (i < slots.length - 1) {
           doc.addPage();
           x = sideMargin;
           y = topMargin;


### PR DESCRIPTION
## Summary
- Add a Cut & Stack Order option (on by default) that reorders cards across PDF pages so each grid position holds a consecutive run
- After cutting a multi-page sheet into piles, stacking those piles left-to-right / top-to-bottom yields sorted order without interleaving cards from each pile